### PR TITLE
Run2bash

### DIFF
--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -8,7 +8,6 @@ connectivity on bringup. As well as other needed features like SSH and DNS.
 Called by iosxr_iso2vbox.py
 '''
 
-import time
 import re
 
 

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -36,6 +36,25 @@ class XrLogin(object):
         self.xr_telnet_sessions.append(self.xr1)
 
     #
+    # Send a global-vrf XR Linux command - wait for prompt
+    # Could do bash -c or run ip netns exec global-vrf bash
+    #
+    def send_operns(self, command):
+        xr1 = self.xr1
+
+        xr1.send("bash -c %s" % command)
+        xr1.wait("[\$#]")
+
+    #
+    # Send a xrnns XR Linux command - wait for prompt
+    #
+    def send_xrnns(self, command):
+        xr1 = self.xr1
+
+        xr1.send("run %s" % command)
+        xr1.wait("[\$#]")
+
+    #
     # Configure a vagrant box
     #
     def setup_networking(self, host_ip=None, gateway=None, allow_root_login=False):
@@ -54,6 +73,8 @@ class XrLogin(object):
         time.sleep(2)
         output = xr1.wait("[\$#]")
         k9 = re.search(r'-k9sec', output)
+        if k9:
+            xr1.log("Crypto k9 image detected")
 
         # Wait for a management interface to be available
         xr1.repeat_until("sh run | inc MgmtEth",
@@ -115,50 +136,48 @@ class XrLogin(object):
         if allow_root_login:
             xr1.send("bash -c sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config_operns")
 
-        #
-        # Send commands to XR Linux
-        #
-        xr1.send("run")
-
         # Add passwordless sudo as required by jenkins
-        xr1.send("echo '####Added by iosxr_setup to give vagrant passwordless access' >> /etc/sudoers")
-        xr1.send("echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers")
+        self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' >> /etc/sudoers")
+        self.send_operns("echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers")
+        self.send_operns("echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers")
 
         # Add public key, so users can ssh without a password
         # https://github.com/purpleidea/vagrant-builder/blob/master/v6/files/ssh.sh
-        xr1.send("[ -d ~vagrant/.ssh ] || mkdir ~vagrant/.ssh")
-        xr1.send("chmod 0700 ~vagrant/.ssh")
-        xr1.send("echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' > ~vagrant/.ssh/authorized_keys")
-        xr1.send("chmod 0600 ~vagrant/.ssh/authorized_keys")
-        xr1.send("chown -R vagrant:vagrant ~vagrant/.ssh/")
+        self.send_operns("[ -d ~vagrant/.ssh ] || mkdir ~vagrant/.ssh")
+        self.send_operns("chmod 0700 ~vagrant/.ssh")
+        self.send_operns("echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' > ~vagrant/.ssh/authorized_keys")
+        self.send_operns("chmod 0600 ~vagrant/.ssh/authorized_keys")
+        self.send_operns("chown -R vagrant:vagrant ~vagrant/.ssh/")
 
         # Add user scratch space - should be able transfer a file to
         # /misc/app_host/scratch using the scp with user vagrant
         # E.g: scp -P 2200 Vagrantfile vagrant@localhost:/misc/app_host/scratch
-        xr1.send("groupadd app_host")
-        xr1.send("usermod -a -G app_host vagrant")
-        xr1.send("mkdir -p /misc/app_host/scratch")
-        xr1.send("chgrp -R app_host /misc/app_host/scratch")
-        xr1.send("chmod 777 /misc/app_host/scratch")
+        self.send_operns("groupadd app_host")
+        self.send_operns("usermod -a -G app_host vagrant")
+        self.send_operns("mkdir -p /misc/app_host/scratch")
+        self.send_operns("chgrp -R app_host /misc/app_host/scratch")
+        self.send_operns("chmod 777 /misc/app_host/scratch")
 
         # Add Cisco OpenDNS IPv4 nameservers as a default DNS resolver
         # almost all users who have internet connectivity will be able to reach those.
         # This will prevent users from needing to supply another Vagrantfile or editing /etc/resolv.conf manually
-        xr1.send("echo '# Cisco OpenDNS IPv4 nameservers' >> /etc/resolv.conf")
-        xr1.send("echo 'nameserver 208.67.222.222' >> /etc/resolv.conf")
-        xr1.send("echo 'nameserver 208.67.220.220' >> /etc/resolv.conf")
+        # Doing this in xrnns because the syncing of cat /etc/netns/global-vrf/resolv.conf to
+        # /etc/resolv.conf requires 'ip netns exec global-vrf bash'.
+        xr1.send("run echo '# Cisco OpenDNS IPv4 nameservers' > /etc/resolv.conf")
+        xr1.send("run echo 'nameserver 208.67.222.222' >> /etc/resolv.conf")
+        xr1.send("run echo 'nameserver 208.67.220.220' >> /etc/resolv.conf")
 
         # Start operns sshd server so vagrant ssh can access app-hosting space
-        xr1.send("service sshd_operns start")
+        self.send_operns("service sshd_operns start")
 
         # Wait for it to come up
-        xr1.repeat_until("service sshd_operns status",
+        xr1.repeat_until("bash -c service sshd_operns status",
                          match_txt="is running...",
                          debug="Check sshd_operns is up",
                          timeout=5)
 
-        xr1.send("chkconfig --add sshd_operns")
-        xr1.send("exit")
+        self.send_operns("chkconfig --add sshd_operns")
+
         xr1.wait("RP/0/RP0/CPU0:ios")
 
         # Set up IOS XR ssh if a k9/crypto image
@@ -166,7 +185,6 @@ class XrLogin(object):
             xr1.send("crypto key generate rsa")
             xr1.wait("How many bits in the modulus")
             xr1.send("")  # Send enter to get default 2048
-            xr1.wait("[\$#]")  # Wait for the prompt
 
     def get_mgmt_ip(self):
         xr1 = self.xr1

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -74,7 +74,7 @@ class XrLogin(object):
         else:
             xr1.log("Non crypto k9 image detected")
 
-        # Determine if the image has the MGBL package needed for GRPC
+        # Determine if the image has the MGBL package needed for gRPC
         output = self.send_operns("rpm -qa | grep mgbl")
         mgbl = re.search(r'-mgbl', output)
         if mgbl:
@@ -116,7 +116,7 @@ class XrLogin(object):
             xr1.send("ssh server vrf default")
             xr1.wait("config")
 
-        # Configure GRPC protocol if MGBL package is available
+        # Configure gRPC protocol if MGBL package is available
         if mgbl:
             xr1.send("grpc")
             xr1.send(" port 57777")

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -50,7 +50,7 @@ class XrLogin(object):
 
         # Determine if the image is a crypto/k9 image or not
         # This will be used to determine whether to configure ssh or not
-        xr1.send("run rpm -qa | grep k9sec")
+        xr1.send("bash -c rpm -qa | grep k9sec")
         time.sleep(2)
         output = xr1.wait("[\$#]")
         k9 = re.search(r'-k9sec', output)
@@ -113,7 +113,7 @@ class XrLogin(object):
 
         # Needed for jenkins if using root password
         if allow_root_login:
-            xr1.send("run sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config_operns")
+            xr1.send("bash -c sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config_operns")
 
         #
         # Send commands to XR Linux

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -75,6 +75,8 @@ class XrLogin(object):
         k9 = re.search(r'-k9sec', output)
         if k9:
             xr1.log("Crypto k9 image detected")
+        else:
+            xr1.log("Non crypto k9 image detected")
 
         # Determine if the image is a full or mini by searching for the mgbl rpm
         # which only exists in the full image
@@ -83,6 +85,10 @@ class XrLogin(object):
         time.sleep(2)
         output = xr1.wait("[\$#]")
         full = re.search(r'-mgbl', output)
+        if full:
+            xr1.log("Full image detected")
+        else:
+            xr1.log("Mini image detected")
 
         # Wait for a management interface to be available
         xr1.repeat_until("sh run | inc MgmtEth",
@@ -144,7 +150,6 @@ class XrLogin(object):
 
         # Add passwordless sudo as required by jenkins
         self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' >> /etc/sudoers")
-        self.send_operns("echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers")
         self.send_operns("echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers")
 
         # Add public key, so users can ssh without a password
@@ -167,7 +172,7 @@ class XrLogin(object):
         # Add Cisco OpenDNS IPv4 nameservers as a default DNS resolver
         # almost all users who have internet connectivity will be able to reach those.
         # This will prevent users from needing to supply another Vagrantfile or editing /etc/resolv.conf manually
-        # Doing this in xrnns because the syncing of cat /etc/netns/global-vrf/resolv.conf to
+        # Doing this in xrnns because the syncing of /etc/netns/global-vrf/resolv.conf to
         # /etc/resolv.conf requires 'ip netns exec global-vrf bash'.
         xr1.send("run echo '# Cisco OpenDNS IPv4 nameservers' > /etc/resolv.conf")
         xr1.send("run echo 'nameserver 208.67.222.222' >> /etc/resolv.conf")


### PR DESCRIPTION
# US109032 : Vagrant Tooling: CRR: iosxr_setup.py logic additions
- Logic to detect full/mini image and not configure grpc if mini
- Change sudo ALL to vagrant user only
- Configure the resolv.conf in XR (using lokhesh sync code) if possible.
  _resolv.conf logic hasn't been changed. This is because the syncing of /etc/netns/global-vrf/resolv.conf to /etc/resolv.conf requires 'ip netns exec global-vrf bash'. I can't find a reliable way to automate this (tried putting it in .profile - but run into permissions issues). Tried it in .ssh/config but that wasn't possible. So keeping this in xrnns for now._
- Move to using bash instead of run where appropriate
- Fix up ssh inconsistencies - lots of timeouts when coming up.
  _Fixed these by going back to bash -c - as 'bash' causes a shell to be created and I get very odd timing issues. However wrapped these in a new function() which applies the config line and waits for the prompt. Execution of the pexpect code is much clearer and logical now, you can actually follow each line of CLI being executed and getting back a prompt._

Tested full and mini images, k9 and non-k9 images.

Timing is MUCH improved and I don't get any SSH authentication errors anymore.

flake8 satisfied.
# Tests

```
==> default: Machine 'default' has a post `vagrant up` message. This is a message
==> default: from the creator of the Vagrantfile, and not from Vagrant itself:
==> default:
==> default:
==> default:     Welcome to the IOS XRv (64-bit) Virtualbox.
==> default:     To connect to the XR Linux shell, use: 'vagrant ssh'.
==> default:     To ssh to the XR Console, use: 'vagrant port' (vagrant version > 1.8)
==> default:     to determine the port that maps to guestport 22,
==> default:     then: 'ssh vagrant@localhost -p <forwarded port>'
==> default:
==> default:     IMPORTANT:  READ CAREFULLY
==> default:     The Software is subject to and governed by the terms and conditions
==> default:     of the End User License Agreement and the Supplemental End User
==> default:     License Agreement accompanying the product, made available at the
==> default:     time of your order, or posted on the Cisco website at
==> default:     www.cisco.com/go/terms (collectively, the 'Agreement').
==> default:     As set forth more fully in the Agreement, use of the Software is
==> default:     strictly limited to internal use in a non-production environment
==> default:     solely for demonstration and evaluation purposes. Downloading,
==> default:     installing, or using the Software constitutes acceptance of the
==> default:     Agreement, and you are binding yourself and the business entity
==> default:     that you represent to the Agreement. If you do not agree to all
==> default:     of the terms of the Agreement, then Cisco is unwilling to license
==> default:     the Software to you and (a) you may not download, install or use the
==> default:     Software, and (b) you may return the Software as more fully set forth
==> default:     in the Agreement.
rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: vagrant ssh
xr-vm_node0_RP0_CPU0:~$ ping google.com
PING google.com (216.58.217.142) 56(84) bytes of data.
64 bytes from iad23s43-in-f142.1e100.net (216.58.217.142): icmp_seq=1 ttl=63 time=9.32 ms
64 bytes from iad23s43-in-f14.1e100.net (216.58.217.142): icmp_seq=2 ttl=63 time=10.1 ms
64 bytes from iad23s43-in-f14.1e100.net (216.58.217.142): icmp_seq=3 ttl=63 time=12.2 ms
64 bytes from iad23s43-in-f14.1e100.net (216.58.217.142): icmp_seq=4 ttl=63 time=9.27 ms
^C
--- google.com ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3006ms
rtt min/avg/max/mdev = 9.274/10.254/12.248/1.210 ms
xr-vm_node0_RP0_CPU0:~$ whoami
vagrant

rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: ssh vagrant@localhost -p 2223
The authenticity of host '[localhost]:2223 ([127.0.0.1]:2223)' can't be established.
RSA key fingerprint is b9:3b:13:c7:a5:40:fa:a5:e3:60:5c:8e:dd:5c:61:3a.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '[localhost]:2223' (RSA) to the list of known hosts.
vagrant@localhost's password:


RP/0/RP0/CPU0:ios#show run
Thu Jun 30 22:43:05.841 UTC
Building configuration...
!! IOS XR Configuration version = 6.1.1.20I
!! Last configuration change at Thu Jun 30 18:32:36 2016 by vagrant
!
telnet vrf default ipv4 server max-servers 10
username vagrant
 group root-lr
 group cisco-support
 secret 5 $1$jgUf$DMwjKda.bsDXbuI7wA0SH/
!
tpa
 address-family ipv4
  update-source MgmtEth0/RP0/CPU0/0
 !
!
interface MgmtEth0/RP0/CPU0/0
 ipv4 address dhcp
!
router static
 address-family ipv4 unicast
  0.0.0.0/0 MgmtEth0/RP0/CPU0/0 10.0.2.2
 !
!
ssh server v2
ssh server vrf default
grpc
 port 57777
!
end
```
