### PR TITLE
Basic tests added to virtualbox generation

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -201,7 +201,7 @@ def main(argv):
     # Move existing ova files. Maybe should just delete
     if os.path.exists(ova_out) and create_ova is True:
         os.remove(ova_out)
-        verboseprint('Found and deleted previosu %s' % ova_out)
+        verboseprint('Found and deleted previous %s' % ova_out)
 
     # Destroy default vagrant box
     verboseprint('Destroy default box')
@@ -367,9 +367,9 @@ def main(argv):
     verboseprint('Creating Virtualbox')
 
     # Add in embedded Vagrantfile
-    vagrant_pathname = os.path.join(pathname, 'include', 'embedded_vagrantfile')
+    vagrantfile_pathname = os.path.join(pathname, 'include', 'embedded_vagrantfile')
 
-    run('vagrant package --base %s --vagrantfile %s --output %s' % (vmname, vagrant_pathname, box_out))
+    run('vagrant package --base %s --vagrantfile %s --output %s' % (vmname, vagrantfile_pathname, box_out))
     verboseprint('Created: %s' % box_out)
 
     # Create OVA
@@ -379,15 +379,14 @@ def main(argv):
         verboseprint('Created OVA %s' % ova_out)
 
     # Run basic sanity tests
-    verboseprint('Testing Virtualbox')
+    verboseprint('Testing VirtualBox')
     iosxr_test_path = os.path.join(pathname, 'iosxr_test.py')
     cmdstring = "python %s %s" % (iosxr_test_path, box_out)
     verboseprint("Running: '%s'" % cmdstring)
     result = (subprocess.check_output(cmdstring, shell=True))
     if result is False:
         # Fail noisily
-        print('Failed basic test, box %s is not sane' % box_out)
-        sys.exit(1)
+        sys.exit('Failed basic test, box %s is not sane' % box_out)
     else:
         verboseprint('Passed basic test, box %s is sane' % box_out)
 

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -141,8 +141,8 @@ class XrLogin(object):
 
         # Add passwordless sudo as required by jenkins
         # sudo not vagrant because we are operating in xrnns and global-vrf user space
-        self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' | tee -a /etc/sudoers")
-        self.send_operns("echo 'vagrant ALL=(ALL) NOPASSWD: ALL' | tee -a /etc/sudoers")
+        self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' (EDITOR='tee -a' visudo)")
+        self.send_operns("echo 'vagrant ALL=(ALL) NOPASSWD: ALL' | (EDITOR='tee -a' visudo)")
 
         # Add public key, so users can ssh without a password
         # https://github.com/purpleidea/vagrant-builder/blob/master/v6/files/ssh.sh

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -2,7 +2,16 @@
 '''
 Author: Rich Wellum (richwellum@gmail.com)
 
-A tool to run some basic tests on a vagrant box
+A tool to run some basic tests on a IOS XRv vagrant box, using pxssh module.
+
+This will verify both IOS XR Linux and IOS XR Console access.
+
+Is called from iosxr_iso2vbox post generation to verify sanity of
+the Virtualbox,
+
+Can also be run manually, like this:
+
+python iosxr_test.py iosxrv-fullk9-x64.box
 '''
 
 from __future__ import print_function
@@ -12,41 +21,32 @@ from pexpect import pxssh
 import subprocess
 import argparse
 import os
+from iosxr_iso2vbox import run
 
 try:
     raw_input
 except NameError:
     raw_input = input
 
+# Some defaults
 terminal_type = 'ansi'
-original_prompt = r"[#$]"
-login_timeout = 0
-host = "localhost"
-user = "vagrant"
+linux_prompt = r"[#$]"
+xr_prompt = "[$#]"
+login_timeout = 10
+hostname = "localhost"
+username = "vagrant"
 password = "vagrant"
 linux_port = 2222
 xr_port = 2223
 
 
-def run(command_string, debug=False):
-    '''
-    Execute a CLI command string and return the result.
-
-    Note this does not handle operators which need whitespace.
-
-    In those cases the raw commands will need to be used.
-
-    E.g. passing grep 'a string separated by spaces'.
-    '''
-    argv = command_string.split()
-    if debug is True:
-        print('argv: %s' % argv)
-    return subprocess.check_output(argv)
-
-
 def bringup_vagrant(input_box):
     '''
     Bring up a vagrant box.
+
+    Clean up ssh keys from the generation of the virtualbox.
+
+    Use pxssh to fascilitate the ssh process.
     '''
     # Clean up Vagrantfile
     try:
@@ -54,79 +54,175 @@ def bringup_vagrant(input_box):
     except OSError:
         pass
 
+    print('Cleaning up ssh keys')
+    run('ssh-keygen -R [localhost]:2222')
+    run('ssh-keygen -R [localhost]:2223')
+
     print("Bringing up '%s'..." % input_box)
-    run('vagrant init XRv64')
+
+    run('vagrant init XRv64')  # Single node for now, in future could bring up two nodes and do more testing
     run('vagrant box add --name XRv64 %s --force' % input_box)
     run('vagrant up')
 
-    count = 0
-    max_count = 1
-    while (count < max_count):
-        try:
-            s = pexpect.pxssh.pxssh()
-            s.login(host, user, password, terminal_type, original_prompt, login_timeout, linux_port)
-            break
-        except pxssh.ExceptionPxssh, e:
-            print("pxssh failed on login, attempt %s/%s. Waiting one minute.." % (count, max_count))
-            print(str(e))
-            count += 1
+    ports = str(subprocess.check_output('vagrant port', shell=True))
+    print(ports)
+
+    try:
+        s = pexpect.pxssh.pxssh()
+        s.login(hostname, username, password, terminal_type, linux_prompt, login_timeout, linux_port)
+    except pxssh.ExceptionPxssh, e:
+        print("pxssh failed on login")
+        print(str(e))
 
 
 def test_linux():
     '''
-    Verify log into IOS XR Linux.
-    Verify user is vagrant.
-    Verify can ping google.com.
+    Verify logging into IOS XR Linux.
+    Verify user is 'vagrant'.
+    Verify can ping 'google.com'.
+    Verify resolv.conf is populated.
     '''
+    print('Testing XR Linux...')
+
     try:
         s = pxssh.pxssh()
-        s.login(host, user, password, terminal_type, original_prompt, login_timeout, linux_port)
+        s.login(hostname, username, password, terminal_type, linux_prompt, login_timeout, linux_port)
 
+        print('Check user:')
         s.sendline('whoami')
-        s.expect('vagrant')
+        result = s.expect(['vagrant', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>Correct user found')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - wrong user name')
+            return False
         s.prompt()
 
+        print('Check pinging the internet:')
         s.sendline("ping -c 4 google.com | grep '64 bytes' | wc -l")
-        s.expect('4')
+        result = s.expect(['4', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>Successfully pinged')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - ping failed')
+            return False
         s.prompt()
 
-        s.sendline('uptime')
+        print('Check resolv.conf is correctly populated:')
+        s.sendline("cat /etc/resolv.conf | grep 220")
+        result = s.expect(['nameserver 208.67.220.220', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>nameserver 208.67.220.220 is successfully populated')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - nameserver 208.67.220.220 is not populated in resolv.conf')
+            return False
         s.prompt()
 
-        s.sendline('cat /etc/resolv.conf | grep 220')
-        s.expect('nameserver 208.67.220.220')
+        s.sendline("cat /etc/resolv.conf | grep 222")
+        result = s.expect(['nameserver 208.67.222.222', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>nameserver 208.67.222.222 is successfully populated')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - nameserver 208.67.220.222 is not populated in resolv.conf')
+            return False
         s.prompt()
 
-        s.sendline('cat /etc/resolv.conf | grep 222')
-        s.expect('nameserver 208.67.222.222')
-        s.prompt()
+        print('Check vagrant public key has been replaced by private:')
+        s.sendline('grep "public" ~/.ssh/authorized_keys -c')
+        result = s.expect(['0', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>SSH public key successfully replaced')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - SSH public key not successfully replaced')
+            return False
 
+        s.prompt()
         s.logout()
-    except pxssh.ExceptionPxssh as e:
-        print("pxssh failed on login.")  # Return this and check in iso2vbox
-        print(e)
-    else:
-        print("Vagrant SSH is sane")  # Return this and check in iso2vbox
-
-
-def test_xr():
-    try:
-        s = pxssh.pxssh()
-        s.login(host, user, password, terminal_type, login_timeout, xr_port)
-        s.sendline('show version')
-        s.prompt()
-        print(s.before)
-        s.sendline('show run')
-        s.prompt()
-        print(s.before)
     except pxssh.ExceptionPxssh as e:
         print("pxssh failed on login.")
         print(e)
+        return False
+    else:
+        print("Vagrant SSH to XR Linux is sane")
+        return True
+
+
+def test_xr():
+    '''
+    Log into IOS XR Console and run some basic sanity tests.
+
+    Verify logging into IOS XR Console directly.
+    Verify show version.
+    Verify show run.
+    '''
+
+    print('Testing XR Console...')
+
+    try:
+        s = pxssh.pxssh()
+        s.force_password = True
+        s.PROMPT = 'RP/0/RP0/CPU0:ios# '
+
+        print('Check logging into XR Console')
+        s.login(hostname, username, password, terminal_type, xr_prompt, login_timeout, xr_port, auto_prompt_reset=False)
+        s.prompt()
+        s.sendline('term length 0')
+        s.prompt()
+        print('==>Successfully logged into XR Console')
+
+        print('Check show version')
+        s.sendline('show version | i cisco IOS XRv x64')
+        result = s.expect(['XRv x64', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>XRv x64 correctly found in show version')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - show version failed')
+            return False
+        s.prompt()
+
+        print('Check show run grpc')
+        s.sendline('show run grpc')
+        result = s.expect(['port 57777', pexpect.EOF, pexpect.TIMEOUT])
+        if result == 0:
+            print('==>GRPC port 57777 correctly found in show run')
+        elif result == 1:
+            print('EOF')
+            return False
+        elif result == 2:
+            print('Timed out - show run failed')
+            return False
+
+        s.prompt()
+        s.logout()
+
+    except pxssh.ExceptionPxssh as e:
+        print("pxssh failed on login.")
+        print(e)
+    else:
+        print("Vagrant SSH to XR Console is sane")
+        return True
 
 
 def main():
-
-    # Grab vagrant box
+    # Get virtualbox
     parser = argparse.ArgumentParser(description='Pass in a vagrant box')
     parser.add_argument("a", nargs='?', default="check_string_for_empty")
     args = parser.parse_args()
@@ -141,10 +237,26 @@ def main():
             print(input_box, 'does not exist')
             sys.exit()
 
-    bringup_vagrant(input_box)
-    test_linux()
-    # test_xr()
+    # Comment this code out when testing iosxr_test.py
+    print('Destroying previous default VM')
     run('vagrant destroy --force')
+
+    # Bring the newly generated virtualbox up
+    bringup_vagrant(input_box)
+
+    # Test IOS XR Linux
+    result_linux = test_linux()
+
+    # Test IOS XR Console
+    result_xr = test_xr()
+
+    # Testing finished - clean up now
+    run('vagrant destroy --force')
+
+    if result_linux or result_xr is False:
+        return False
+    else:
+        return True
 
 if __name__ == "__main__":
     main()

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+'''
+Author: Rich Wellum (richwellum@gmail.com)
+
+A tool to run some basic tests on a vagrant box
+'''
+
+from __future__ import print_function
+import sys
+import pexpect
+from pexpect import pxssh
+import subprocess
+import argparse
+import os
+
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
+terminal_type = 'ansi'
+original_prompt = r"[#$]"
+login_timeout = 0
+host = "localhost"
+user = "vagrant"
+password = "vagrant"
+linux_port = 2222
+xr_port = 2223
+
+
+def run(command_string, debug=False):
+    '''
+    Execute a CLI command string and return the result.
+
+    Note this does not handle operators which need whitespace.
+
+    In those cases the raw commands will need to be used.
+
+    E.g. passing grep 'a string separated by spaces'.
+    '''
+    argv = command_string.split()
+    if debug is True:
+        print('argv: %s' % argv)
+    return subprocess.check_output(argv)
+
+
+def bringup_vagrant(input_box):
+    '''
+    Bring up a vagrant box.
+    '''
+    # Clean up Vagrantfile
+    try:
+        os.remove('Vagrantfile')
+    except OSError:
+        pass
+
+    print("Bringing up '%s'..." % input_box)
+    run('vagrant init XRv64')
+    run('vagrant box add --name XRv64 %s --force' % input_box)
+    run('vagrant up')
+
+    count = 0
+    max_count = 1
+    while (count < max_count):
+        try:
+            s = pexpect.pxssh.pxssh()
+            s.login(host, user, password, terminal_type, original_prompt, login_timeout, linux_port)
+            break
+        except pxssh.ExceptionPxssh, e:
+            print("pxssh failed on login, attempt %s/%s. Waiting one minute.." % (count, max_count))
+            print(str(e))
+            count += 1
+
+
+def test_linux():
+    '''
+    Verify log into IOS XR Linux.
+    Verify user is vagrant.
+    Verify can ping google.com.
+    '''
+    try:
+        s = pxssh.pxssh()
+        s.login(host, user, password, terminal_type, original_prompt, login_timeout, linux_port)
+
+        s.sendline('whoami')
+        s.expect('vagrant')
+        s.prompt()
+
+        s.sendline("ping -c 4 google.com | grep '64 bytes' | wc -l")
+        s.expect('4')
+        s.prompt()
+
+        s.sendline('uptime')
+        s.prompt()
+
+        s.sendline('cat /etc/resolv.conf | grep 220')
+        s.expect('nameserver 208.67.220.220')
+        s.prompt()
+
+        s.sendline('cat /etc/resolv.conf | grep 222')
+        s.expect('nameserver 208.67.222.222')
+        s.prompt()
+
+        s.logout()
+    except pxssh.ExceptionPxssh as e:
+        print("pxssh failed on login.")  # Return this and check in iso2vbox
+        print(e)
+    else:
+        print("Vagrant SSH is sane")  # Return this and check in iso2vbox
+
+
+def test_xr():
+    try:
+        s = pxssh.pxssh()
+        s.login(host, user, password, terminal_type, login_timeout, xr_port)
+        s.sendline('show version')
+        s.prompt()
+        print(s.before)
+        s.sendline('show run')
+        s.prompt()
+        print(s.before)
+    except pxssh.ExceptionPxssh as e:
+        print("pxssh failed on login.")
+        print(e)
+
+
+def main():
+
+    # Grab vagrant box
+    parser = argparse.ArgumentParser(description='Pass in a vagrant box')
+    parser.add_argument("a", nargs='?', default="check_string_for_empty")
+    args = parser.parse_args()
+
+    if args.a == 'check_string_for_empty':
+        print('No argument given')
+        print('Usage: iosxr_test.py <boxname>')
+        sys.exit(1)
+    else:
+        input_box = args.a
+        if not os.path.exists(input_box):
+            print(input_box, 'does not exist')
+            sys.exit()
+
+    bringup_vagrant(input_box)
+    test_linux()
+    # test_xr()
+    run('vagrant destroy --force')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**US112939**
- Added a simple but powerful unit test module, that test for some basic sanities after the box has been successfully created.
- This includes both IOS XR Linux and IOS XR Console testing.
- The tool can be run manually on a box, but is also incorporated into iso2vbox.py automatically.
- This provides peace of mind that the generated box is sane, especially during development where I have made seemingly innocuous changes that have broken the box.
- The unit test can be expanded easily for more tests, and even can be expanded to bring up two nodes, and run tests between them.
- Also cleaned up paths where there was a lot of duplication.
- Also Changed to use visudo to modify /etc/sudoers.
- Also removed saving copies of the previous generated boxes and now just clean them up.

Output looks like the following:

```
==> iosxrv-fullk9-x64: Creating Virtualbox
==> iosxrv-fullk9-x64: Created: /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box
**==> iosxrv-fullk9-x64: Testing Virtualbox**
**==> iosxrv-fullk9-x64: Running: 'python /Users/rwellum/Desktop/Boxes/iosxrv-x64-vbox/iosxr_test.py /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box'**
/Users/rwellum/.ssh/known_hosts updated.
Original contents retained as /Users/rwellum/.ssh/known_hosts.old
/Users/rwellum/.ssh/known_hosts updated.
Original contents retained as /Users/rwellum/.ssh/known_hosts.old
**==> iosxrv-fullk9-x64: Passed basic test, box /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box is sane**
==> iosxrv-fullk9-x64: Single node use:
==> iosxrv-fullk9-x64:  vagrant init 'IOS XRv'
==> iosxrv-fullk9-x64:  vagrant box add --name 'IOS XRv' /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box --force
==> iosxrv-fullk9-x64:  vagrant up
==> iosxrv-fullk9-x64: Multinode use:
==> iosxrv-fullk9-x64:  Copy './iosxrv-x64-vbox/vagrantfiles/simple-mixed-topo/Vagrantfile' to the directory running vagrant and do:
==> iosxrv-fullk9-x64:  vagrant box add --name 'IOS XRv' /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box --force
==> iosxrv-fullk9-x64:  vagrant up
==> iosxrv-fullk9-x64:  Or: 'vagrant up rtr1', 'vagrant up rtr2'
==> iosxrv-fullk9-x64: Note that both the XR Console and the XR linux shell username and password is vagrant/vagrant
rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]:
```
