### PR TITLE
vagrantfile fixes - US109034

### DIFF
--- a/include/embedded_vagrantfile
+++ b/include/embedded_vagrantfile
@@ -9,22 +9,14 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
   # Give IOS XRv (64-bit) 400 seconds to come up
   config.vm.boot_timeout = 400
 
-  # Internal network for GE interfaces.
-  # config.vm.network "private_network", type: "dhcp"
-
-  # 57722 is the operns_sshd (22 is XR)
+  # Port 57722 is XR linux (operns_sshd)
   config.vm.network :forwarded_port, guest: 57722, host: 2222, auto_correct: true
+  # Port 2 is XR Console
   config.vm.network :forwarded_port, guest: 22, host: 2223, id: 'ssh', auto_correct: true
   config.ssh.forward_agent = true
   config.ssh.guest_port = 57722
@@ -44,7 +36,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision :shell, :inline => "nslookup #{SecureRandom.uuid}.iosxrv-x64.cisco.com 208.67.222.222 &>> /dev/null && echo nslookup_s >> /tmp/state.txt || echo nslookup_f >> /tmp/state.txt"
 
   config.vm.post_up_message = "
-    Welcome to the IOS XRv (64-bit) Virtualbox.
+    Welcome to the IOS XRv (64-bit) VirtualBox.
     To connect to the XR Linux shell, use: 'vagrant ssh'.
     To ssh to the XR Console, use: 'vagrant port' (vagrant version > 1.8)
     to determine the port that maps to guestport 22,
@@ -66,59 +58,4 @@ Vagrant.configure(2) do |config|
     the Software to you and (a) you may not download, install or use the
     Software, and (b) you may return the Software as more fully set forth
     in the Agreement."
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # . This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
 end

--- a/include/embedded_vagrantfile
+++ b/include/embedded_vagrantfile
@@ -14,9 +14,9 @@ Vagrant.configure(2) do |config|
   # Give IOS XRv (64-bit) 400 seconds to come up
   config.vm.boot_timeout = 400
 
-  # Port 57722 is XR linux (operns_sshd)
+  # Port 57722 is XR linux (sshd_operns)
   config.vm.network :forwarded_port, guest: 57722, host: 2222, auto_correct: true
-  # Port 2 is XR Console
+  # Port 22 is XR Console
   config.vm.network :forwarded_port, guest: 22, host: 2223, id: 'ssh', auto_correct: true
   config.ssh.forward_agent = true
   config.ssh.guest_port = 57722

--- a/iosxr_setup.py
+++ b/iosxr_setup.py
@@ -141,7 +141,7 @@ class XrLogin(object):
 
         # Add passwordless sudo as required by jenkins
         # sudo not vagrant because we are operating in xrnns and global-vrf user space
-        self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' (EDITOR='tee -a' visudo)")
+        self.send_operns("echo '####Added by iosxr_setup to give vagrant passwordless access' | (EDITOR='tee -a' visudo)")
         self.send_operns("echo 'vagrant ALL=(ALL) NOPASSWD: ALL' | (EDITOR='tee -a' visudo)")
 
         # Add public key, so users can ssh without a password

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -172,8 +172,8 @@ Subject: A new IOS XRv (64-bit) vagrant box has been posted to artifactory %s
 Reason for update: %s
 \nVagrant Box: %s
 \nTo use:
-\n vagrant init xrv64
-\n vagrant box add --name xrv64 %s --force
+\n vagrant init 'IOS XRv'
+\n vagrant box add --name 'IOS XRv' %s --force
 \n vagrant up
 \n vagrant ssh
         """ % (sender, receiver, location, message, box_out, box_out)

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -296,6 +296,12 @@ def main():
     # Testing finished - clean up now
     run('vagrant destroy --force')
 
+    # Clean up Vagrantfile
+    try:
+        os.remove('Vagrantfile')
+    except OSError:
+        pass
+
     print('result_linux=%s, result_xr=%s' % (result_linux, result_xr))
 
     if result_linux is False or result_xr is False:


### PR DESCRIPTION
- Cleaned up embedded vagrantfile (mainly comments)
- Fixed a bug in setup
- Clean up Vagrantfile in test module.

This was also a research into:
- Question regarding why the need to loop when disconnecting serial? 
  config.vm.provider 'virtualbox' do |v|
- Potentially move id: ‘ssh’ => ‘XR Console’ - but where is the string visible?

I can confirm that the 'id' has to be ssh - I tried 'xrv64' 'XR Console' etc and it wouldn't load.

Similarly the serials needs to be embedded in a 'config.vm.provider 'virtualbox' do |v|' block.
