### PR TITLE
Change to using argparse.

### DIFF
--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -51,21 +51,17 @@ def main(argv):
     receiver = os.environ.get('ARTIFACTORY_RECEIVER')
 
     if artifactory_username is None:
-        print('==> Please set ARTIFACTORY_USERNAME in your environment')
-        print('E.g. export "ARTIFACTORY_USERNAME=<username>"')
-        sys.exit()
+        sys.exit("==> Please set ARTIFACTORY_USERNAME in your environment\n"
+                 "E.g., 'export ARTIFACTORY_USERNAME=<username>'")
     if artifactory_password is None:
-        print('==> Please set ARTIFACTORY_PASSWORD in your environment')
-        print('E.g. export "ARTIFACTORY_PASSWORD=<PASSWORD>"')
-        sys.exit()
+        sys.exit("==> Please set ARTIFACTORY_PASSWORD in your environment\n"
+                 "E.g. export 'ARTIFACTORY_PASSWORD=<PASSWORD>'")
     if sender is None:
-        print('==> Please set SENDER in your environment')
-        print('==> E.g. export "ARTIFACTORY_SENDER=$USER@me.com"')
-        sys.exit()
+        sys.exit("==> Please set SENDER in your environment\n"
+                 "==> E.g. export 'ARTIFACTORY_SENDER=$USER@me.com'")
     if receiver is None:
-        print('==> Please set RECEIVER in your environment')
-        print('==> E.g. export "ARTIFACTORY_RECEIVER=updates@me.com"')
-        sys.exit()
+        sys.exit("==> Please set RECEIVER in your environment\n"
+                 "==> E.g. export 'ARTIFACTORY_RECEIVER=updates@me.com'")
 
     # Suck in the input ISO and handle errors
     try:
@@ -140,10 +136,9 @@ def main(argv):
         location = os.environ.get('ARTIFACTORY_LOCATION_SNAPSHOT')
 
     if location is None:
-        print('==> Please set LOCATION_RELEASE or LOCATION_SNAPSHOT in your environment')
-        print('==> E.g.: export "ARTIFACTORY_LOCATION_SNAPSHOT=http://location", or:')
-        print('==> E.g.: export "ARTIFACTORY_LOCATION_RELEASE=http://location"')
-        sys.exit()
+        sys.exit("==> Please set LOCATION_RELEASE or LOCATION_SNAPSHOT in your environment\n"
+                 "==> E.g.: export 'ARTIFACTORY_LOCATION_SNAPSHOT=http://location', or: \n"
+                 "==> E.g.: export 'ARTIFACTORY_LOCATION_RELEASE=http://location'")
 
     box_out = os.path.join(location, boxname)
 

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -33,25 +33,8 @@ from __future__ import print_function
 import sys
 import os
 import getopt
-import subprocess
 import smtplib
-
-
-def run(command_string, debug=False):
-    '''
-    Execute a CLI command string and return the result.
-
-    Note this does not handle operators which need whitespace.
-
-    In those cases the raw commands will need to be used.
-
-    E.g. passing grep 'a string separated by spaces'.
-    '''
-    argv = command_string.split()
-    if debug is True:
-        print ('argv: %s' % argv)
-    result = subprocess.check_output(argv)
-    return result
+from iosxr_iso2vbox import run
 
 
 def main(argv):
@@ -69,15 +52,19 @@ def main(argv):
 
     if artifactory_username is None:
         print('==> Please set ARTIFACTORY_USERNAME in your environment')
+        print('E.g. export "ARTIFACTORY_USERNAME=<username>"')
         sys.exit()
     if artifactory_password is None:
         print('==> Please set ARTIFACTORY_PASSWORD in your environment')
+        print('E.g. export "ARTIFACTORY_PASSWORD=<PASSWORD>"')
         sys.exit()
     if sender is None:
         print('==> Please set SENDER in your environment')
+        print('==> E.g. export "ARTIFACTORY_SENDER=$USER@me.com"')
         sys.exit()
     if receiver is None:
         print('==> Please set RECEIVER in your environment')
+        print('==> E.g. export "ARTIFACTORY_RECEIVER=updates@me.com"')
         sys.exit()
 
     # Suck in the input ISO and handle errors
@@ -154,6 +141,8 @@ def main(argv):
 
     if location is None:
         print('==> Please set LOCATION_RELEASE or LOCATION_SNAPSHOT in your environment')
+        print('==> E.g.: export "ARTIFACTORY_LOCATION_SNAPSHOT=http://location", or:')
+        print('==> E.g.: export "ARTIFACTORY_LOCATION_RELEASE=http://location"')
         sys.exit()
 
     box_out = os.path.join(location, boxname)

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -156,8 +156,8 @@ Subject: A new IOS XRv (64-bit) vagrant box has been posted to artifactory %s
 Reason for update: %s
 \nVagrant Box: %s
 \nTo use:
-\n vagrant init xrv64
-\n vagrant box add --name xrv64 %s --force
+\n vagrant init 'IOS XRv'
+\n vagrant box add --name 'IOS XRv' %s --force
 \n vagrant up
 \n vagrant ssh
         """ % (sender, receiver, location, message, box_out, box_out)


### PR DESCRIPTION
Move to using argparse.

Help looks like:

rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: iosxrv-x64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -o -v -h
usage: iosxr_iso2vbox.py [-h] [-a [ARTIFACTORY]] [-o] [-v] ISO_FILE

A tool to create an IOS XRv Vagrant VirtualBox box from an IOS XRv ISO.

The ISO will be installed, booted, configured and unit-tested.
"vagrant ssh" provides access to IOS XR Linux global-vrf namespace
with internet access.

positional arguments:
  ISO_FILE              local ISO filename or remote URI ISO filename...

optional arguments:
  -h, --help            show this help message and exit
  -a [ARTIFACTORY], --artifactory [ARTIFACTORY]
                        add optional reason for uploading this box
  -o, --create_ova      additionally use vboxmange to export an OVA
  -v, --verbose         turn on verbose messages

E.g.: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -a 'new image' -o -v

Tested it of course and flake8 is good.

Just don't like the "--artifactory [ARTIFACTORY]" - as that's a bit ugly.
