### PR TITLE
Md5

### DIFF
--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -178,12 +178,13 @@ Subject: A new IOS XRv (64-bit) vagrant box has been posted to artifactory %s
 
 Reason for update: %s
 \nVagrant Box: %s
+\nHash File is: %s
 \nTo use:
 \n vagrant init 'IOS XRv'
 \n vagrant box add --name 'IOS XRv' %s --force
 \n vagrant up
 \n vagrant ssh
-        """ % (sender, receiver, location, message, box_out, box_out)
+        """ % (sender, receiver, location, message, box_out, hash_out, box_out)
 
     if args.verbose == logging.DEBUG or test_only:
         print('Email is:')

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -178,7 +178,7 @@ Subject: A new IOS XRv (64-bit) vagrant box has been posted to artifactory %s
 
 Reason for update: %s
 \nVagrant Box: %s
-\nHash File is: %s
+\nHash File  : %s
 \nTo use:
 \n vagrant init 'IOS XRv'
 \n vagrant box add --name 'IOS XRv' %s --force

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -134,12 +134,12 @@ def main(argv):
 
     logger.setLevel(level=args.verbose)
 
-    logger.debug("Input box is:  '%s'" % input_box)
-    logger.debug("Message is:    '%s'" % message)
-    logger.debug("Sender is:     '%s'" % sender)
-    logger.debug("Receiver is:   '%s'" % receiver)
-    logger.debug("Release is:    '%s'" % artifactory_release)
-    logger.debug("Test Only is:  '%s'" % test_only)
+    logger.debug("Input box is: '%s'" % input_box)
+    logger.debug("Message is:   '%s'" % message)
+    logger.debug("Sender is:    '%s'" % sender)
+    logger.debug("Receiver is:  '%s'" % receiver)
+    logger.debug("Release is:   '%s'" % artifactory_release)
+    logger.debug("Test Only is: '%s'" % test_only)
 
     '''
     Copy the box to artifactory. This will most likely change to Atlas, or maybe both.

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -48,7 +48,7 @@ def generate_hash(file):
     # SHA256 the box file and store in same location
     sha256_hash = hashlib.sha256(open(file, 'rb').read()).hexdigest()
     logger.debug('SHA256: %s' % sha256_hash)
-    hash_file = os.path.splitext(file)[0] + '.sha256'
+    hash_file = os.path.splitext(file)[0] + '.sha256.txt'
     f = open(hash_file, 'w')
     f.write(sha256_hash)
     f.close()


### PR DESCRIPTION
# Symptom

TME's had asked for a sha/md5 sum to be uploaded with each vagrant box - as infosec wanted the extra security:

"Rich, do you do a checksum for the XRV images? Info sec is worried we’re going to distribute an image with a virus in it and (insert impending doom). We should probably provide a checksum or start thinking about how we can digitally sign the image. Is this taken care of in any way today or can we start providing MD5 or SHA1 key users can check against?"
# Problem

New functionality
# Solution

Update iosxrv-store.py to generate a sha256 key when an image is uploaded. Place that key in a file that is named the same as the box (but .sha256 instead of .box). Upload that file to artifactory too. Update the email message when running the tool.
# Testing

Tested both manually and with current jenkins job which generates the boxes and stores them

Verified that the sha256 file is uploaded to artifactory and named correctly.

Output example from Jenkins
- bash -c iosxrv-x64-vbox/iosxr_store_box.py /nobackup/feadmin/jenkins/workspace/team_appdevci/iosxrv64_iso2vbox/machines/iosxrv-fullk9-x64-6.1.1.24I/iosxrv-fullk9-x64.box -m 'SIT 6.1.1 Snapshot Version 6.1.1.24I' -v
  [iosxr_store_box.py:137 -                 main()] Input box is:  '/nobackup/feadmin/jenkins/workspace/team_appdevci/iosxrv64_iso2vbox/machines/iosxrv-fullk9-x64-6.1.1.24I/iosxrv-fullk9-x64.box'
  [iosxr_store_box.py:138 -                 main()] Message is:    'SIT 6.1.1 Snapshot Version 6.1.1.24I'
  [iosxr_store_box.py:139 -                 main()] Sender is:     'feadmin@cisco.com'
  [iosxr_store_box.py:140 -                 main()] Receiver is:   'xr64-updates@cisco.com'
  [iosxr_store_box.py:141 -                 main()] Release is:    'False'
  [iosxr_store_box.py:142 -                 main()] Test Only is:  'False'
  [iosxr_store_box.py:50 -        generate_hash()] SHA256: 6783002f055f3670890118fa31daa62f7803a12781e85bef1ceca183392498b9
  [iosxr_store_box.py:55 -        generate_hash()] Hash file is /nobackup/feadmin/jenkins/workspace/team_appdevci/iosxrv64_iso2vbox/machines/iosxrv-fullk9-x64-6.1.1.24I/iosxrv-fullk9-x64.sha256
  [iosxr_store_box.py:169 -                 main()] Copying /nobackup/feadmin/jenkins/workspace/team_appdevci/iosxrv64_iso2vbox/machines/iosxrv-fullk9-x64-6.1.1.24I/iosxrv-fullk9-x64.box to http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest/iosxrv-fullk9-x64.box
  [iosxr_store_box.py:171 -                 main()] Copying /nobackup/feadmin/jenkins/workspace/team_appdevci/iosxrv64_iso2vbox/machines/iosxrv-fullk9-x64-6.1.1.24I/iosxrv-fullk9-x64.sha256 to http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest/iosxrv-fullk9-x64.sha256
  [iosxr_store_box.py:197 -                 main()] Successfully sent update email
  Email is:
  From: feadmin@cisco.com
  To: IOS XRv (64-bit) Box Interest xr64-updates@cisco.com
  Subject: A new IOS XRv (64-bit) vagrant box has been posted to artifactory http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest

Reason for update: SIT 6.1.1 Snapshot Version 6.1.1.24I

Vagrant Box: http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest/iosxrv-fullk9-x64.box

Hash File is: http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest/iosxrv-fullk9-x64.sha256

To use:

 vagrant init 'IOS XRv'

 vagrant box add --name 'IOS XRv' http://engci-maven-master.cisco.com/artifactory/appdevci-snapshot/XRv64/latest/iosxrv-fullk9-x64.box --force

 vagrant up

 vagrant ssh

Notifying upstream projects of job completion
Finished: SUCCESS
