### PR TITLE
Store changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,12 +108,12 @@ How to use this tool
       [iosxr_iso2vbox.py:624 -                 main() ] Running basic unit tests on Vagrant VirtualBox...
       [iosxr_iso2vbox.py:645 -                 main() ] Passed basic test, box /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box is sane
 
-6. Full help
+6. Full help output
 
    ::
 
       iosxrv-x64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -h
-      usage: iosxr_iso2vbox.py [-h] [-a ['New box reason']] [-o] [-s] [-d] [-v]
+      usage: iosxr_iso2vbox.py [-h] [-o] [-s] [-d] [-v]
              ISO_FILE
 
       A tool to create an IOS XRv Vagrant VirtualBox box from an IOS XRv ISO.
@@ -127,9 +127,6 @@ How to use this tool
 
       optional arguments:
       -h, --help            show this help message and exit
-      -a ['New box reason'], --artifactory ['New box reason']
-                            Upload box to Artifactory. You can optionally specify
-                            a reason for uploading this box
       -o, --create_ova      additionally use vboxmanage to export an OVA
       -s, --skip_test       skip unit testing
       -d, --debug           will exit with the VM in a running state. Use: socat
@@ -139,7 +136,55 @@ How to use this tool
       E.g.:
       box build with local iso: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso
       box build with remote iso: iosxr-xrv64-vbox/iosxr_iso2vbox.py user@server:/myboxes/iosxrv-fullk9-x64.iso
-      box build with ova export, verbose and upload to artifactory: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -o -v -a 'New Image'
+      box build with ova export and verbose: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -o -v
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The iosxr_store.py tool is:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A tool written to copy a generated box to a repository, with a
+generated message to an alias.
+
+^^^^^^^^^^^^^^^^^^^^^^
+How to use this tool
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: iosxrv-x64-vbox/iosxr_store_box.py -h
+   usage: iosxr_store_box.py [-h] [-m MESSAGE] [-r] -s SUBDIR [-v] [-t] BOX_FILE
+
+   A tool to upload an image to a maven repo like artifactory using curl, the image typically being a vagrant virtualbox.
+   User can select snapshot or release, the release images get synced to devhub.cisco.com - where they are available to customers.
+   This tool also sends an email out to an email address or an alias to inform them of the new image.
+   It is designed to be called from other tools, like iosxr_ios2vbox.py.
+
+   It will rely on the following environment variables to work:
+     ARTIFACTORY_USERNAME
+     ARTIFACTORY_PASSWORD
+     ARTIFACTORY_LOCATION_SNAPSHOT
+     ARTIFACTORY_LOCATION_RELEASE
+     ARTIFACTORY_SENDER
+     ARTIFACTORY_RECEIVER
+
+   positional arguments:
+     BOX_FILE              BOX filename
+
+     optional arguments:
+       -h, --help            show this help message and exit
+       -m MESSAGE, --message MESSAGE
+                             Optionally specify a reason for uploading this box
+       -r, --release         upload to '$ARTIFACTORY_LOCATION_RELEASE' rather than
+                             '$ARTIFACTORY_LOCATION_SNAPSHOT'.
+       -s SUBDIR, --subdirectory SUBDIR
+                             subdirectory to upload to, e.g '6.1.1', 'stable'
+       -v, --verbose         turn on verbose messages
+       -t, --test_only       test only, do not store the box or send an email
+
+       E.g.:
+       iosxrv-x64-vbox/iosxr_store_box.py iosxrv-fullk9-x64.box --release --verbose --message 'A new box because...'
+       iosxrv-x64-vbox/iosxr_store_box.py iosxrv-fullk9-x64.box --release, --message 'A new box because...'
+       iosxrv-x64-vbox/iosxr_store_box.py iosxrv-fullk9-x64.box -r -v -m
+       'Latest box for release.'
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 How to install Vagrant, VirtualBox and socat

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ How to use this tool
 
 ::
 
-   rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: iosxrv-x64-vbox/iosxr_store_box.py -h
+   iosxrv-x64-vbox/iosxr_store_box.py -h
    usage: iosxr_store_box.py [-h] [-m MESSAGE] [-r] -s SUBDIR [-v] [-t] BOX_FILE
 
    A tool to upload an image to a maven repo like artifactory using curl, the image typically being a vagrant virtualbox.

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,6 @@ economic benefit of using their existing laptop hardware.
 Currently this supports IOS XRv (64-bit) only but will be adapted to
 also handle `IOS XRv 9000`_ images.
 
-Test for githooks
-
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 An IOS XRv (64-bit) VM:
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ How to use this tool
 
    ::
 
-      iosxrv-x64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -h
+      $ iosxrv-x64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -h
       usage: iosxr_iso2vbox.py [-h] [-o] [-s] [-d] [-v]
              ISO_FILE
 
@@ -150,7 +150,7 @@ How to use this tool
 
 ::
 
-   iosxrv-x64-vbox/iosxr_store_box.py -h
+   $ iosxrv-x64-vbox/iosxr_store_box.py -h
    usage: iosxr_store_box.py [-h] [-m MESSAGE] [-r] -s SUBDIR [-v] [-t] BOX_FILE
 
    A tool to upload an image to a maven repo like artifactory using curl, the image typically being a vagrant virtualbox.

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -352,9 +352,7 @@ def configure_xr(argv):
 
 def main(argv):
     input_iso = ''
-    copy_to_artifactory = False
     create_ova = False
-    artifactory_reason = ''
 
     parser = argparse.ArgumentParser(
         formatter_class=RawDescriptionHelpFormatter,
@@ -368,9 +366,6 @@ def main(argv):
         "box build with ova export, verbose and upload to artifactory: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -o -v -a 'New Image'\n")
     parser.add_argument('ISO_FILE',
                         help='local ISO filename or remote URI ISO filename...')
-    parser.add_argument('-a', '--artifactory', nargs='?', metavar="'New box reason'",
-                        const='No reason for update specified',
-                        help='Upload box to Artifactory. You can optionally specify a reason for uploading this box')
     parser.add_argument('-o', '--create_ova', action='store_true',
                         help='additionally use VBoxManage to export an OVA')
     parser.add_argument('-s', '--skip_test', action='store_true',
@@ -394,12 +389,6 @@ def main(argv):
     else:
         # Local image
         input_iso = args.ISO_FILE
-
-    # Handle artifactory
-    if args.artifactory is not None:
-        copy_to_artifactory = True
-        if args.artifactory is not 'No reason for update specified':
-            artifactory_reason = args.artifactory
 
     # Handle create OVA
     create_ova = args.create_ova
@@ -651,16 +640,6 @@ def main(argv):
         os.remove('Vagrantfile')
     except OSError:
         pass
-
-    # Copy to artifactory if -a
-    if copy_to_artifactory is True:
-        logger.info('Copying Vagrant Virtualbox to Artifactory')
-        iosxr_store_box_path = os.path.join(pathname, 'iosxr_store_box.py')
-        if args.verbose == logging.DEBUG:
-            add_verbose = '-v'
-
-        cmd_string = "python %s %s %s -m '%s'" % (iosxr_store_box_path, box_out, add_verbose, artifactory_reason)
-        subprocess.call(cmd_string, shell=True)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -108,6 +108,8 @@ def main(argv):
                         help='Optionally specify a reason for uploading this box')
     parser.add_argument('-r', '--release', action='store_true',
                         help="upload to '$ARTIFACTORY_LOCATION_RELEASE' rather than '$ARTIFACTORY_LOCATION_SNAPSHOT'.")
+    parser.add_argument('-s', '--sub_dir', dest='subdir', required=True,
+                        help="subdirectory to upload to, e.g '6.1.1', 'stable'")
     parser.add_argument('-v', '--verbose',
                         action='store_const', const=logging.DEBUG,
                         default=logging.INFO, help='turn on verbose messages')
@@ -123,6 +125,7 @@ def main(argv):
     message = args.message
     artifactory_release = args.release
     test_only = args.test_only
+    subdir = args.subdir
 
     if not input_box:
         sys.exit('No input box detected, use -b to specify a box')
@@ -140,6 +143,7 @@ def main(argv):
     logger.debug("Receiver is:  '%s'" % receiver)
     logger.debug("Release is:   '%s'" % artifactory_release)
     logger.debug("Test Only is: '%s'" % test_only)
+    logger.debug("Sub dir is:   '%s'" % subdir)
 
     '''
     Copy the box to artifactory. This will most likely change to Atlas, or maybe both.
@@ -157,9 +161,9 @@ def main(argv):
                  "E.g.: export 'ARTIFACTORY_LOCATION_SNAPSHOT=http://location', or: \n"
                  "E.g.: export 'ARTIFACTORY_LOCATION_RELEASE=http://location'")
 
-    box_out = os.path.join(location, boxname)
+    box_out = os.path.join(location, subdir, boxname)
     generate_hash(input_box)
-    hash_out = os.path.join(location, os.path.basename(hash_file))
+    hash_out = os.path.join(location, subdir, os.path.basename(hash_file))
 
     if test_only is True:
         logger.debug('Test only: copying %s to %s' % (input_box, box_out))

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -48,7 +48,7 @@ def generate_hash(file):
     # SHA256 the box file and store in same location
     sha256_hash = hashlib.sha256(open(file, 'rb').read()).hexdigest()
     logger.debug('SHA256: %s' % sha256_hash)
-    hash_file = os.path.splitext(file)[0] + '.sha256.txt'
+    hash_file = os.path.splitext(file)[0] + '.box.sha256.txt'
     f = open(hash_file, 'w')
     f.write(sha256_hash)
     f.close()

--- a/iosxr_store_box.py
+++ b/iosxr_store_box.py
@@ -48,7 +48,7 @@ def generate_hash(file):
     # SHA256 the box file and store in same location
     sha256_hash = hashlib.sha256(open(file, 'rb').read()).hexdigest()
     logger.debug('SHA256: %s' % sha256_hash)
-    hash_file = os.path.splitext(file)[0] + '.box.sha256.txt'
+    hash_file = os.path.basename(file) + '.sha256.txt'
     f = open(hash_file, 'w')
     f.write(sha256_hash)
     f.close()
@@ -108,7 +108,7 @@ def main(argv):
                         help='Optionally specify a reason for uploading this box')
     parser.add_argument('-r', '--release', action='store_true',
                         help="upload to '$ARTIFACTORY_LOCATION_RELEASE' rather than '$ARTIFACTORY_LOCATION_SNAPSHOT'.")
-    parser.add_argument('-s', '--sub_dir', dest='subdir', required=True,
+    parser.add_argument('-s', '--subdirectory', dest='subdir', required=True,
                         help="subdirectory to upload to, e.g '6.1.1', 'stable'")
     parser.add_argument('-v', '--verbose',
                         action='store_const', const=logging.DEBUG,

--- a/vagrantfiles/simple-mixed-topo/Vagrantfile
+++ b/vagrantfiles/simple-mixed-topo/Vagrantfile
@@ -10,9 +10,9 @@ Vagrant.configure(2) do |config|
       # Forward a port for grpc server access from the host, for eg. port 57777 configured on XR, forwarded to 57778 on host
       node.vm.network :forwarded_port, guest: 57777, host: 57778, id: "grpc", auto_correct: true
 
-      # gig0/0/0/0 connected to link2, gig00/0/1 connected to link1, gig0/0/0/2 connected to link3, auto-config not supported.
-      node.vm.network :private_network, virtualbox__intnet: "link2", auto_config: false
+      # gig0/0/0/0 connected to link1, gig00/0/1 connected to link2, gig0/0/0/2 connected to link3, auto-config not supported.
       node.vm.network :private_network, virtualbox__intnet: "link1", auto_config: false
+      node.vm.network :private_network, virtualbox__intnet: "link2", auto_config: false
       node.vm.network :private_network, virtualbox__intnet: "link3", auto_config: false
 
     end
@@ -20,9 +20,9 @@ Vagrant.configure(2) do |config|
     config.vm.define "rtr2" do |node|
       node.vm.box =  "IOS XRv"
 
-      # gig0/0/0/0 connected to link1, gig0/0/0/1 connected to link3, auto-config not supported
+      # gig0/0/0/0 connected to link1, gig0/0/0/1 connected to link2, auto-config not supported
       node.vm.network :private_network, virtualbox__intnet: "link1", auto_config: false
-      node.vm.network :private_network, virtualbox__intnet: "link3", auto_config: false
+      node.vm.network :private_network, virtualbox__intnet: "link2", auto_config: false
 
       node.vm.provider "virtualbox" do |v|
         # Optional, forward the XR console serial port a TCP port on the host
@@ -32,12 +32,10 @@ Vagrant.configure(2) do |config|
       end
     end
 
-
     config.vm.define "devbox" do |node|
       node.vm.box =  "ubuntu/trusty64"
 
       # eth1 connected to link2, auto_config is supported for an ubuntu instance
       node.vm.network :private_network, virtualbox__intnet: "link2", ip: "11.1.1.2"
-
     end
 end


### PR DESCRIPTION
# Symptom

Changed the directory structure of both release and snapshot artifactory offerings, to have a 'release', 'latest' and 'archive'. This is to update store.py to be able to select a sub directory.
# Problem

New development.
# Solution

Add a -s - subdir option, integrate it.

Couple of other little fixes here too, readme and then muddled links in a sample Vagrantfile.
# Testing

Jenkins job ran multiple times and we can see images going to the correct places.
