### PR TITLE
Better logging.

### DIFF
--- a/include/embedded_vagrantfile
+++ b/include/embedded_vagrantfile
@@ -9,11 +9,6 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
-  puts 'Welcome to the IOS XRv (64-bit) Vagrant VirtualBox.'
-  puts 'This instance will take several minutes to come up,'
-  puts 'while IOS XR is booting.'
-  puts 'Please be patient and wait until Vagrant is finished.'
-
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
   # Give IOS XRv (64-bit) 400 seconds to come up

--- a/include/embedded_vagrantfile
+++ b/include/embedded_vagrantfile
@@ -9,6 +9,11 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
+  puts 'Welcome to the IOS XRv (64-bit) Vagrant VirtualBox.'
+  puts 'This instance will take several minutes to come up,'
+  puts 'while IOS XR is booting.'
+  puts 'Please be patient and wait until Vagrant is finished.'
+
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
   # Give IOS XRv (64-bit) 400 seconds to come up

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -111,7 +111,7 @@ def run(cmd, hide_error=False, cont_on_error=False):
         logger.error('Error output for: ' + s_cmd)
         logger.error(tup_output[1])
         if not cont_on_error:
-            sys.exit('Quiting due to run command error')
+            sys.exit('Quitting due to run command error')
         else:
             logger.debug('Continuing despite error cont_on_error=%d', cont_on_error)
 
@@ -633,7 +633,8 @@ def main(argv):
     logger.info('Note that both the XR Console and the XR linux shell username and password is vagrant/vagrant')
 
     # Clean up default test VM
-    run(['vagrant', 'destroy', '--force'], cont_on_error=True)
+    if not args.skip_test:
+        run(['vagrant', 'destroy', '--force'], cont_on_error=True)
 
     # Clean up Vagrantfile
     try:

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -108,10 +108,10 @@ def run(cmd, hide_error=False, cont_on_error=False):
     logger.debug(tup_output[0])
 
     if not hide_error and 0 != output.returncode:
-        print('Error output for: ' + s_cmd)
-        print(tup_output[1])
+        logger.error('Error output for: ' + s_cmd)
+        logger.error(tup_output[1])
         if not cont_on_error:
-            sys.exit(0)
+            sys.exit('Quiting due to run command error')
         else:
             logger.debug('Continuing despite error cont_on_error=%d', cont_on_error)
 

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -365,7 +365,7 @@ def main(argv):
         "box build with remote iso: iosxr-xrv64-vbox/iosxr_iso2vbox.py user@server:/myboxes/iosxrv-fullk9-x64.iso\n" +
         "box build with ova export, verbose and upload to artifactory: iosxr-xrv64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso -o -v -a 'New Image'\n")
     parser.add_argument('ISO_FILE',
-                        help='local ISO filename or remote URI ISO filename...')
+                        help='local ISO filename or remote URI ISO filename')
     parser.add_argument('-o', '--create_ova', action='store_true',
                         help='additionally use VBoxManage to export an OVA')
     parser.add_argument('-s', '--skip_test', action='store_true',

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -247,12 +247,9 @@ def main():
     args = parser.parse_args()
     verbose = args.verbose
 
-    if args.BOX_FILE == 'check_string_for_empty':
-        sys.exit('No argument given, Usage: iosxr_test.py <boxname>')
-    else:
-        input_box = args.BOX_FILE
-        if not os.path.exists(input_box):
-            sys.exit(input_box, 'does not exist')
+    input_box = args.BOX_FILE
+    if not os.path.exists(input_box):
+        sys.exit(input_box, 'does not exist')
 
     logger.setLevel(level=args.verbose)
 

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -81,12 +81,15 @@ def bringup_vagrant():
     # Use vagrant to init, add and bring up the inputted Vagrant VirtualBox
     logger.debug("Bringing up '%s'..." % input_box)
 
+    logger.debug('vagrant init XRv64-test')
     output = run(['vagrant', 'init', 'XRv64-test'])
     logger.debug(output)
 
+    logger.debug('vagrant box add --name XRv64-test %s --force' % input_box)
     output = run(['vagrant', 'box', 'add', '--name', 'XRv64-test', input_box, '--force'])
     logger.debug(output)
 
+    logger.debug('vagrant up')
     output = run(['vagrant', 'up'])
     logger.debug(output)
 

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -242,7 +242,7 @@ def main():
 
     parser = argparse.ArgumentParser(description='Run basic unit-test on a Vagrant VirtualBox')
     parser.add_argument('BOX_FILE',
-                        help='local Vagrant VirtualBox filename...')
+                        help='local Vagrant VirtualBox filename')
     parser.add_argument('-v', '--verbose',
                         action='store_const', const=logging.DEBUG,
                         default=logging.INFO, help='turn on verbose messages')

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -41,6 +41,9 @@ hostname = "localhost"
 username = "vagrant"
 password = "vagrant"
 
+iosxr_port = 0
+linux_port = 0
+
 
 def check_result(result, success_message):
     '''
@@ -63,34 +66,41 @@ def check_result(result, success_message):
 
 def bringup_vagrant():
     '''
-    Bring up a vagrant box.
-
-    Clean up ssh keys from the generation of the virtualbox.
-
-    Use pxssh to fascilitate the ssh process.
+    Bring up a vagrant box and test the ssh connection.
     '''
+
     # Clean up Vagrantfile
     try:
         os.remove('Vagrantfile')
     except OSError:
         pass
 
+    global iosxr_port
+    global linux_port
+
+    # Use vagrant to init, add and bring up the inputted Vagrant VirtualBox
     logger.debug("Bringing up '%s'..." % input_box)
 
-    run(['vagrant', 'init', 'XRv64-test'])  # Single node for now, in future could bring up two nodes and do more testing
-    run(['vagrant', 'box', 'add', '--name', 'XRv64-test', input_box, '--force'])
-    output = run(['vagrant', 'up'])
-    print(output)
+    output = run(['vagrant', 'init', 'XRv64-test'])
+    logger.debug(output)
 
-    # Find the correct port to connect to
-    port = subprocess.check_output('vagrant port --guest 57722', shell=True)
-    logger.debug('Connecting to port %s' % port)
+    output = run(['vagrant', 'box', 'add', '--name', 'XRv64-test', input_box, '--force'])
+    logger.debug(output)
+
+    output = run(['vagrant', 'up'])
+    logger.debug(output)
+
+    # Find the ports to connect to linux and xr
+    linux_port = subprocess.check_output('vagrant port --guest 57722', shell=True)
+    iosxr_port = subprocess.check_output('vagrant port --guest 22', shell=True)
+
+    logger.debug('Connecting to port %s' % linux_port)
 
     try:
         s = pxssh.pxssh(options={
             "StrictHostKeyChecking": "no",
             "UserKnownHostsFile": "/dev/null"})
-        s.login(hostname, username, password, terminal_type, linux_prompt, login_timeout, port)
+        s.login(hostname, username, password, terminal_type, linux_prompt, login_timeout, linux_port)
         logger.debug('Sucessfully brought up VM and logged in')
         s.logout()
     except pxssh.ExceptionPxssh, e:
@@ -106,7 +116,6 @@ def test_linux():
     Verify resolv.conf is populated.
     '''
     logger.debug('Testing XR Linux...')
-    linux_port = subprocess.check_output('vagrant port --guest 57722', shell=True)
     logger.debug('Connecting to port %s' % linux_port)
 
     try:
@@ -168,15 +177,14 @@ def test_xr():
     Verify logging into IOS XR Console directly.
     Verify show version.
     Verify show run.
+    Verify grpc is configured if a full image.
     '''
-    global iosxr_port
 
     if 'k9' not in input_box:
         logger.warning('Not a crypto image, will not test XR as no SSH to access.')
         return True
 
     logger.debug('Testing XR Console...')
-    iosxr_port = subprocess.check_output('vagrant port --guest 22', shell=True)
     logger.debug('Connecting to port %s' % iosxr_port)
 
     try:
@@ -229,8 +237,9 @@ def main():
     global input_box
     global verbose
 
-    parser = argparse.ArgumentParser(description='Pass in a vagrant box')
-    parser.add_argument("a", nargs='?', default="check_string_for_empty")
+    parser = argparse.ArgumentParser(description='Run basic unit-test on a Vagrant VirtualBox')
+    parser.add_argument('BOX_FILE',
+                        help='local Vagrant VirtualBox filename...')
     parser.add_argument('-v', '--verbose',
                         action='store_const', const=logging.DEBUG,
                         default=logging.INFO, help='turn on verbose messages')
@@ -238,10 +247,10 @@ def main():
     args = parser.parse_args()
     verbose = args.verbose
 
-    if args.a == 'check_string_for_empty':
+    if args.BOX_FILE == 'check_string_for_empty':
         sys.exit('No argument given, Usage: iosxr_test.py <boxname>')
     else:
-        input_box = args.a
+        input_box = args.BOX_FILE
         if not os.path.exists(input_box):
             sys.exit(input_box, 'does not exist')
 


### PR DESCRIPTION
# Symptom

iosxrv_test.py:
. is not displaying full output (vagrant commands). This makes it hard to debug on jenkins as it looks like it just jumps from starting unit-tests to finishing.
. Badly named arg for Vagrant Virtualbox
. Finding the ports redundancy in code
. Couple of improved comments

iosxrv_iso2vbox.py:
. run command errors not seen when run() is called from another module.
# Problem

Small part of the User Story to handle errors better and the modularity US.
# Solution

Use debug.error instead of print() in iso2vbox
Grab the output of the vagrant init, add and up commands and display them in test.py
Rename the args better in test.py
Also fixed up the ports so we only search for them once.
# Testing
1. Better arguments leads to better help output:

```
rwellum@RWELLUM-M-34DF:[~/Desktop/Boxes]: iosxrv-x64-vbox/iosxr_test.py -h
usage: iosxr_test.py [-h] [-v] BOX_FILE

Run basic unit-test on a Vagrant VirtualBox

positional arguments:
  BOX_FILE       local Vagrant VirtualBox filename...

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  turn on verbose messages
```
1. Output of running the test stage.

```
[iosxr_iso2vbox.py:610 -                 main()] Running basic unit tests on Vagrant VirtualBox...
[iosxr_test.py:82 -      bringup_vagrant()] Bringing up '/Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64-latest-C/iosxrv-fullk9-x64-latest-C.box'...
[iosxr_test.py:85 -      bringup_vagrant()] A `Vagrantfile` has been placed in this directory. You are now
ready to `vagrant up` your first virtual environment! Please read
the comments in the Vagrantfile as well as documentation on
`vagrantup.com` for more information on using Vagrant.

[iosxr_test.py:88 -      bringup_vagrant()] ==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'XRv64-test' (v0) for provider:
    box: Unpacking necessary files from: file:///Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64-latest-C/iosxrv-fullk9-x64-latest-C.box
==> box: Successfully added box 'XRv64-test' (v0) for 'virtualbox'!

[iosxr_test.py:91 -      bringup_vagrant()] Bringing machine 'default' up with 'virtualbox' provider...
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.

==> default: Machine 'default' has a post `vagrant up` message. This is a message
==> default: from the creator of the Vagrantfile, and not from Vagrant itself:
==> default:
==> default:
==> default:     Welcome to the IOS XRv (64-bit) VirtualBox.
==> default:     To connect to the XR Linux shell, use: 'vagrant ssh'.
==> default:     To ssh to the XR Console, use: 'vagrant port' (vagrant version > 1.8)
==> default:     to determine the port that maps to guestport 22,
==> default:     then: 'ssh vagrant@localhost -p <forwarded port>'
==> default:
==> default:     IMPORTANT:  READ CAREFULLY
==> default:     The Software is subject to and governed by the terms and conditions
==> default:     of the End User License Agreement and the Supplemental End User
==> default:     License Agreement accompanying the product, made available at the
==> default:     time of your order, or posted on the Cisco website at
==> default:     www.cisco.com/go/terms (collectively, the 'Agreement').
==> default:     As set forth more fully in the Agreement, use of the Software is
==> default:     strictly limited to internal use in a non-production environment
==> default:     solely for demonstration and evaluation purposes. Downloading,
==> default:     installing, or using the Software constitutes acceptance of the
==> default:     Agreement, and you are binding yourself and the business entity
==> default:     that you represent to the Agreement. If you do not agree to all
==> default:     of the terms of the Agreement, then Cisco is unwilling to license
==> default:     the Software to you and (a) you may not download, install or use the
==> default:     Software, and (b) you may return the Software as more fully set forth
==> default:     in the Agreement.

[iosxr_test.py:97 -      bringup_vagrant()] Connecting to port 2222

[iosxr_test.py:104 -      bringup_vagrant()] Sucessfully brought up VM and logged in
[iosxr_test.py:118 -           test_linux()] Testing XR Linux...
[iosxr_test.py:119 -           test_linux()] Connecting to port 2222

[iosxr_test.py:128 -           test_linux()] Successfully logged into XR Linux
[iosxr_test.py:130 -           test_linux()] Check user:
[iosxr_test.py:54 -         check_result()] Test passed: Correct user found
[iosxr_test.py:137 -           test_linux()] Check pinging the internet:
[iosxr_test.py:54 -         check_result()] Test passed: Successfully pinged
[iosxr_test.py:144 -           test_linux()] Check resolv.conf is correctly populated:
[iosxr_test.py:54 -         check_result()] Test passed: nameserver 208.67.220.220 is successfully populated
[iosxr_test.py:54 -         check_result()] Test passed: nameserver 208.67.222.222 is successfully populated
[iosxr_test.py:157 -           test_linux()] Check vagrant public key has been replaced by private:
[iosxr_test.py:54 -         check_result()] Test passed: SSH public key successfully replaced
[iosxr_test.py:169 -           test_linux()] Vagrant SSH to XR Linux is sane
[iosxr_test.py:187 -              test_xr()] Testing XR Console...
[iosxr_test.py:188 -              test_xr()] Connecting to port 2223

[iosxr_test.py:202 -              test_xr()] Successfully logged into XR Console
[iosxr_test.py:204 -              test_xr()] Check show version:
[iosxr_test.py:54 -         check_result()] Test passed: XRv x64 correctly found in show version
[iosxr_test.py:211 -              test_xr()] Check show run for username vagrant:
[iosxr_test.py:54 -         check_result()] Test passed: Username vagrant found
[iosxr_test.py:219 -              test_xr()] Check show run for grpc:
[iosxr_test.py:54 -         check_result()] Test passed: grpc is configured
[iosxr_test.py:231 -              test_xr()] Vagrant SSH to XR Console is sane
[iosxr_test.py:268 -                 main()] result_linux=True, result_xr=True
[iosxr_test.py:273 -                 main()] Both IOS XR and IOS Linux test suites passed
[iosxr_iso2vbox.py:622 -                 main()] Single node use:
[iosxr_iso2vbox.py:623 -                 main()]  vagrant init 'IOS XRv'
[iosxr_iso2vbox.py:624 -                 main()]  vagrant box add --name 'IOS XRv' /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64-latest-C/iosxrv-fullk9-x64-latest-C.box --force
[iosxr_iso2vbox.py:625 -                 main()]  vagrant up
[iosxr_iso2vbox.py:627 -                 main()] Multinode use:
[iosxr_iso2vbox.py:628 -                 main()]  Copy './iosxrv-x64-vbox/vagrantfiles/simple-mixed-topo/Vagrantfile' to the directory running vagrant and do:
[iosxr_iso2vbox.py:629 -                 main()]  vagrant box add --name 'IOS XRv' /Users/rwellum/Desktop/Boxes/machines/iosxrv-fullk9-x64-latest-C/iosxrv-fullk9-x64-latest-C.box --force
[iosxr_iso2vbox.py:630 -                 main()]  vagrant up
[iosxr_iso2vbox.py:631 -                 main()]  Or: 'vagrant up rtr1', 'vagrant up rtr2'
[iosxr_iso2vbox.py:633 -                 main()] Note that both the XR Console and the XR linux shell username and password is vagrant/vagrant
[iosxr_iso2vbox.py:95 -                  run()] Command: 'vagrant destroy --force'

[iosxr_iso2vbox.py:105 -                  run()] Command succeeded with code 0:
[iosxr_iso2vbox.py:107 -                  run()] Output for: vagrant destroy --force
[iosxr_iso2vbox.py:108 -                  run()] ==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...
```
