### PR TITLE
ZTP properly disabled and couple more logs

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -178,15 +178,17 @@ def configure_xr(argv):
 
         for attempt in range(total):
             try:
+                logger.debug("Looking for '%s' in output of '%s'\n" % (pattern, command))
                 child.sendline(command)
                 child.expect(pattern, 5)
                 found_match = True
+                logger.debug("Found '%s' in '%s'\n" % (pattern, command))
                 break
             except pexpect.TIMEOUT:
                 logger.debug("Iteration '%s' out of '%s'", attempt, total)
 
         if not found_match:
-            raise Exception("No '%s' in '%s'" % (pattern, command))
+            raise Exception("No '%s' in '%s'\n" % (pattern, command))
 
     try:
         child = pexpect.spawn("socat TCP:%s:%s -,raw,echo=0,escape=0x1d" % (localhost, CONSOLE_PORT))
@@ -216,6 +218,10 @@ def configure_xr(argv):
         child.expect(prompt)
 
         # ZTP causes some startup issues so disable it during box creation
+        child.sendline("run mkdir -p /disk0:/ztp/state")
+        child.expect(prompt)
+        child.sendline("run touch /disk0:/ztp/state/state_is_complete")
+        child.expect(prompt)
         child.sendline("ztp terminate noprompt")
         child.expect(prompt)
 

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -178,17 +178,17 @@ def configure_xr(argv):
 
         for attempt in range(total):
             try:
-                logger.debug("Looking for '%s' in output of '%s'\n" % (pattern, command))
+                logger.debug("Looking for '%s' in output of '%s'" % (pattern, command))
                 child.sendline(command)
                 child.expect(pattern, 5)
                 found_match = True
-                logger.debug("Found '%s' in '%s'\n" % (pattern, command))
+                logger.debug("Found '%s' in '%s'" % (pattern, command))
                 break
             except pexpect.TIMEOUT:
                 logger.debug("Iteration '%s' out of '%s'", attempt, total)
 
         if not found_match:
-            raise Exception("No '%s' in '%s'\n" % (pattern, command))
+            raise Exception("No '%s' in '%s'" % (pattern, command))
 
     try:
         child = pexpect.spawn("socat TCP:%s:%s -,raw,echo=0,escape=0x1d" % (localhost, CONSOLE_PORT))


### PR DESCRIPTION
# Symptom

ZTP was not properly disabled.
xr_wait_for_cli can be improved
# Problem

Loads of ZTP actions still occurring which could interfere with my bootstrap CLI
# Solution

Create a file that ZTP uses to see if it needs to activate.
Add better logging in the wait for cli code to display what it is looking for
# Testing

none
