### PR TITLE
Add metadata

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -230,6 +230,10 @@ def configure_xr(argv):
         child.sendline("ztp terminate noprompt")
         child.expect(prompt)
 
+        # Get the image build information
+        child.sendline("show version")
+        child.expect(prompt)
+
         # Determine if the image is a crypto/k9 image or not
         # This will be used to determine whether to configure ssh or not
         child.sendline("bash -c rpm -qa | grep k9sec")

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -125,13 +125,13 @@ def cleanup_vmname(name, box_name):
     '''
     # Power off VM if it is running
     vms_list_running = run(['VBoxManage', 'list', 'runningvms'])
-    if name in vms_list_running:
+    if re.search('"' + name + '"', vms_list_running):
         logger.debug("'%s' is running, powering off...", name)
         run(['VBoxManage', 'controlvm', name, 'poweroff'])
 
     # Unregister and delete
     vms_list = run(['VBoxManage', 'list', 'vms'])
-    if name in vms_list:
+    if re.search('"' + name + '"', vms_list):
         logger.debug("'%s' is registered, unregistering and deleting", name)
         run(['VBoxManage', 'unregistervm', box_name, '--delete'])
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,3 @@
+{
+    "provider": "virtualbox"
+}


### PR DESCRIPTION
1) Add metadata.json to generated box for better interoperability with Vagrant.
2) Print "show version" when bringing up XR, to aid troubleshooting of automated builds
3) Smarter detection of running VMs so that VM name "foo.bar" doesn't get mistaken for VM name "foo".