### PR TITLE
Fix metadata.json issue

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -633,7 +633,7 @@ def vbox_to_vagrant(vmname, box_dir):
     logger.info("Adding metadata.json to final box")
     run(['gunzip', '--force', '-S', '.box', box_out])
     with tarfile.open(box_tmp, 'a') as tarf:
-        tarf.add("./metadata.json")
+        tarf.add(os.path.join(pathname, "metadata.json"))
     run(['gzip', '--force', '-S', '.box', box_tmp])
     # gzip automatically cleans up - no need for os.remove(box_tmp)
 


### PR DESCRIPTION
Symptom
=======
Error thrown while running iosxr_iso2vbox.py

Problem
=======
While running the script from outside the iosxrv-x64-vbox directory, I get the following error:

[2016-12-13 20:15:51,577:INFO - vbox_to_vagrant:633] Adding metadata.json to final box
Traceback (most recent call last):
  File "iosxrv-x64-vbox/iosxr_iso2vbox.py", line 737, in <module>
    main()
  File "iosxrv-x64-vbox/iosxr_iso2vbox.py", line 703, in main
    box_out = vbox_to_vagrant(vmname, box_dir)
  File "iosxrv-x64-vbox/iosxr_iso2vbox.py", line 636, in vbox_to_vagrant
    tarf.add("./metadata.json")
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 2006, in add
    tarinfo = self.gettarinfo(name, arcname)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 1878, in gettarinfo
    statres = os.lstat(name)
OSError: [Errno 2] No such file or directory: './metadata.json'

Solution
========
Change one line of code to add the pathname to the metadata.json file.

Testing
=======
bubanerj@BUBANERJ-M-J098 ~/Ciscostuff/Boxes $ python iosxrv-x64-vbox/iosxr_iso2vbox.py iosxrv-fullk9-x64.iso
[2016-12-13 21:07:12,084:INFO    :create_vbox_vm      :434] Creating and configuring VirtualBox VM
[2016-12-13 21:07:15,313:INFO    :configure_xr        :200] Logging into Vagrant Virtualbox and configuring IOS XR
[2016-12-13 21:13:38,003:INFO    :vbox_to_vagrant     :617] Generating Vagrant VirtualBox
[2016-12-13 21:17:43,361:INFO    :vbox_to_vagrant     :633] Adding metadata.json to final box
[2016-12-13 21:18:43,189:INFO    :vbox_to_vagrant     :640] Created: /Users/bubanerj/Ciscostuff/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box
[2016-12-13 21:18:43,605:INFO    :main                :714] Running basic unit tests on Vagrant VirtualBox...
[2016-12-13 21:28:25,870:INFO    :main                :295] Both IOS XR and IOS Linux test suites passed
[2016-12-13 21:28:25,871:INFO    :cleanup_vagrant     :238] Cleaning up...
[2016-12-13 21:28:30,312:INFO    :main                :722] Single node use:
[2016-12-13 21:28:30,312:INFO    :main                :723]  vagrant init 'IOS XRv'
[2016-12-13 21:28:30,312:INFO    :main                :724]  vagrant box add --name 'IOS XRv' /Users/bubanerj/Ciscostuff/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box --force
[2016-12-13 21:28:30,312:INFO    :main                :725]  vagrant up
[2016-12-13 21:28:30,312:INFO    :main                :727] Multinode use:
[2016-12-13 21:28:30,312:INFO    :main                :728]  Copy './iosxrv-x64-vbox/vagrantfiles/simple-mixed-topo/Vagrantfile' to the directory running vagrant and do:
[2016-12-13 21:28:30,312:INFO    :main                :729]  vagrant box add --name 'IOS XRv' /Users/bubanerj/Ciscostuff/Boxes/machines/iosxrv-fullk9-x64/iosxrv-fullk9-x64.box --force
[2016-12-13 21:28:30,312:INFO    :main                :730]  vagrant up
[2016-12-13 21:28:30,313:INFO    :main                :731]  Or: 'vagrant up rtr1', 'vagrant up rtr2'
[2016-12-13 21:28:30,313:INFO    :main                :733] Note that both the XR Console and the XR linux shell username and password is vagrant/vagrant