### PR TITLE
Reliability improvements

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -749,7 +749,7 @@ def main():
         sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
         from iosxr_test import main as test_main
-        test_main(box_out, args.verbose)
+        test_main(box_out, args.verbose, args.debug)
 
     logger.info('Single node use:')
     logger.info(" vagrant init 'IOS XRv'")

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -101,7 +101,7 @@ def run(cmd, hide_error=False, cont_on_error=False):
     Allow the ability to hide errors and also to continue on errors.
     '''
     s_cmd = ' '.join(cmd)
-    logger.debug("Command: '%s'\n", s_cmd)
+    logger.debug("Command: '%s'", s_cmd)
 
     output = subprocess.Popen(cmd,
                               stdout=subprocess.PIPE,
@@ -113,8 +113,7 @@ def run(cmd, hide_error=False, cont_on_error=False):
     else:
         logger.debug('Command succeeded with code %d:', output.returncode)
 
-    logger.debug('Output for: ' + s_cmd)
-    logger.debug(tup_output[0])
+    logger.debug('Output for "%s":\n%s', s_cmd, tup_output[0])
 
     if not hide_error and 0 != output.returncode:
         logger.error('Error output for: ' + s_cmd)
@@ -269,6 +268,8 @@ def configure_xr(verbosity):
 
         # Get the image build information
         child.sendline("show version")
+        child.expect(prompt)
+        child.sendline("run cat /etc/build-info.txt")
         child.expect(prompt)
 
         # Determine if the image is a crypto/k9 image or not

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -402,6 +402,9 @@ def configure_xr(verbosity):
         child.expect(prompt)
         child.sendline("bash -c chown -R vagrant:vagrant ~vagrant/.ssh/")
         child.expect(prompt)
+        # Sanity check
+        child.sendline("bash -c cat ~vagrant/.ssh/authorized_keys")
+        child.expect(prompt)
 
         # Add Cisco OpenDNS IPv4 nameservers as a default DNS resolver
         # almost all users who have internet connectivity will be able to reach those.
@@ -437,6 +440,11 @@ def configure_xr(verbosity):
 
         logger.debug('Waiting 30 seconds...')
         time.sleep(30)
+
+        logger.info("Issuing shutdown command")
+        child.sendline("run shutdown -P now")
+        logger.debug('Waiting 10 seconds...')
+        time.sleep(10)
 
     except pexpect.TIMEOUT:
         raise pexpect.TIMEOUT('Timeout (%s) exceeded in read().' % str(child.timeout))

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -109,15 +109,15 @@ def run(cmd, hide_error=False, cont_on_error=False):
     tup_output = output.communicate()
 
     if output.returncode != 0:
-        logger.debug('Command failed with code %d:', output.returncode)
+        logger.debug('Command failed with code %d', output.returncode)
     else:
-        logger.debug('Command succeeded with code %d:', output.returncode)
+        logger.debug('Command succeeded with code %d', output.returncode)
 
-    logger.debug('Output for "%s":\n%s', s_cmd, tup_output[0])
+    if tup_output[0].strip():
+        logger.debug('Output for "%s":\n%s', s_cmd, tup_output[0])
 
     if not hide_error and 0 != output.returncode:
-        logger.error('Error output for: ' + s_cmd)
-        logger.error(tup_output[1])
+        logger.error('Error output for "%s":\n%s', s_cmd, tup_output[1])
         if not cont_on_error:
             raise AbortScriptException(
                 "Command '{0}' failed with return code {1}".format(

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -333,12 +333,13 @@ def configure_xr(verbosity):
             child.sendline("ssh server vrf default")
             child.expect("config")
 
-        # Configure gRPC protocol if MGBL package is available
-        if mgbl:
-            child.sendline("grpc")
-            child.expect("config-grpc")
-            child.sendline(" port 57777")
-            child.expect("config-grpc")
+        # We no longer enable gRPC by default as it consumes a large
+        # amount of memory in recent images.
+        # if mgbl:
+        #     child.sendline("grpc")
+        #     child.expect("config-grpc")
+        #     child.sendline(" port 57777")
+        #     child.expect("config-grpc")
 
         # Commit changes and end
         child.sendline("commit")

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -228,7 +228,7 @@ def configure_xr(verbosity):
     logger.info('Logging into Vagrant Virtualbox and configuring IOS XR')
 
     localhost = 'localhost'
-    prompt = r"[$#]$"
+    prompt = r"ios[$#]$"
 
     def xr_cli_wait_for_output(command, pattern):
         """Execute a XR CLI command and try to find a pattern.

--- a/iosxr_test.py
+++ b/iosxr_test.py
@@ -180,7 +180,6 @@ def test_xr():
     Verify logging into IOS XR Console directly.
     Verify show version.
     Verify show run.
-    Verify grpc is configured if a full image.
     '''
 
     if 'k9' not in input_box:
@@ -218,13 +217,15 @@ def test_xr():
             return False
         s.prompt()
 
-        if 'full' in input_box:
-            logger.debug('Check show run for grpc:')
-            s.sendline('show run grpc')
-            output = s.expect(['port 57777', pexpect.EOF, pexpect.TIMEOUT])
-            if not check_result(output, 'grpc is configured'):
-                return False
-            s.prompt()
+        # gRPC is no longer enabled by default due to increasing memory
+        # requirements. If we decide to re-enable it, here:
+        # if 'full' in input_box:
+        #     logger.debug('Check show run for grpc:')
+        #     s.sendline('show run grpc')
+        #     output = s.expect(['port 57777', pexpect.EOF, pexpect.TIMEOUT])
+        #     if not check_result(output, 'grpc is configured'):
+        #         return False
+        #     s.prompt()
 
         s.logout()
     except pxssh.ExceptionPxssh as e:
@@ -292,6 +293,9 @@ def main(vbox=None, verbosity=logging.INFO, debug=False):
         raise AbortScriptException('%s does not exist' % input_box)
 
     logger.setLevel(level=verbose)
+    # Since we are importing methods from the main iso2vbox module,
+    # ensure its logging is also set according to our preference.
+    logging.getLogger('iosxr_iso2vbox').setLevel(level=verbose)
 
     try:
         # Bring the newly generated virtualbox up


### PR DESCRIPTION
Symptom
=======
Nightly Jenkins builds are unreliable and frequently fail

Problem
=======
Various, but most notably:
1. gRPC uses a lot more memory in recent IOS XR versions (due to increased YANG support), resulting in memory starvation.
2. `configure_xr` is not picky enough about the "prompt" string, causing it to think that the device has returned to the prompt when it hasn't actually finished the previous command.
3. System is unceremoniously powered off when done, possibly resulting in data loss.
4. Cleanup from previous failures deletes any stale .vdi file but doesn't unregister the disk from VirtualBox, resulting in intermittent VirtualBox errors.

Solution
========
1. No longer configure gRPC by default
2. Improve `configure_xr` logic to be more discriminate.
3. Issue `shutdown -P now` and wait a few seconds before powering off the VM
4. Check for registered hdds and unregister if needed.
5. Improve a few debug messages
6. Add debug-on-failure support to the test script.

Testing
=======
Manual runs are consistently succeeding, previous issues are not seen.