### PR TITLE
Update iosxr_iso2vbox.py to build new images with 5120 MB RAM. 

### DIFF
--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -490,7 +490,7 @@ def define_vbox_vm(vmname, base_dir, input_iso):
         logger.debug('%s is a mini image, RAM allocated is %s MB',
                      input_iso, ram)
     elif 'full' in input_iso:
-        ram = 4096
+        ram = 5120
         logger.debug('%s is a full image, RAM allocated is %s MB',
                      input_iso, ram)
     else:


### PR DESCRIPTION
Symptom
=======
IOS-XR vagrant boxes running out of memory when Telemetry/GRPC are enabled.  The increase in the memory requirements for GRPC and the manageability features necessitates the push to 5120 MB RAM (until XR LXC begins to expand with the memory provided to the VM - currently it remains statically tied to the RAM allocated during build/installation).

Problem
=======
4096 MB RAM is on the border for the usage with Telemetry/GRPC features. Minimum requirement has now jumped to 5120 MB RAM.

Solution
========
Current solution is to set VM memory to 5120 MB RAM during the build process. Long term solution will be to make XR LXC memory usage flexible based on VM memory provided.

Testing
=======
Manual Vagrant box build was successful.
