### PR TITLE
Crypto image creation failing at "crypto key generate" on 7.0.2

### DIFF
--- a/.vagrant/rgloader/loader.rb
+++ b/.vagrant/rgloader/loader.rb
@@ -1,9 +1,0 @@
-# This file loads the proper rgloader/loader.rb file that comes packaged
-# with Vagrant so that encoded files can properly run with Vagrant.
-
-if ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"]
-  require File.expand_path(
-    "rgloader/loader", ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"])
-else
-  raise "Encoded files can't be read outside of the Vagrant installer."
-end

--- a/.vagrant/rgloader/loader.rb
+++ b/.vagrant/rgloader/loader.rb
@@ -1,0 +1,9 @@
+# This file loads the proper rgloader/loader.rb file that comes packaged
+# with Vagrant so that encoded files can properly run with Vagrant.
+
+if ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"]
+  require File.expand_path(
+    "rgloader/loader", ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"])
+else
+  raise "Encoded files can't be read outside of the Vagrant installer."
+end

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -432,12 +432,12 @@ def configure_xr(verbosity):
         if crypto:
             child.sendline("crypto key generate rsa")
             index = child.expect(["How many bits in the modulus", "really want to replace"])
-            if index == 0:
-                child.sendline("2048")  # Send enter to get default 2048
-                child.expect(prompt)  # Wait for the prompt
-            if index == 1:
-                child.sendline("no")
-                child.expect(prompt)  # Wait for the prompt
+        if index == 0:
+            child.sendline("2048")  # Send enter to get default 2048
+            child.expect(prompt)  # Wait for the prompt
+        if index == 1:
+            child.sendline("no")
+            child.expect(prompt)  # Wait for the prompt
 
         # Final check to make sure MGMT stayed up
         xr_cli_wait_for_output('show ipv4 interface MgmtEth0/RP0/CPU0/0', '10.0.2.15')

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -431,8 +431,12 @@ def configure_xr(verbosity):
         # Set up IOS XR ssh if a k9/crypto image
         if crypto:
             child.sendline("crypto key generate rsa")
-            child.expect("How many bits in the modulus")
+            index = child.expect(["How many bits in the modulus", "really want to replace"])
+        if index == 0:
             child.sendline("2048")  # Send enter to get default 2048
+            child.expect(prompt)  # Wait for the prompt
+        if index == 1:
+            child.sendline("no")
             child.expect(prompt)  # Wait for the prompt
 
         # Final check to make sure MGMT stayed up

--- a/iosxr_iso2vbox.py
+++ b/iosxr_iso2vbox.py
@@ -432,12 +432,12 @@ def configure_xr(verbosity):
         if crypto:
             child.sendline("crypto key generate rsa")
             index = child.expect(["How many bits in the modulus", "really want to replace"])
-        if index == 0:
-            child.sendline("2048")  # Send enter to get default 2048
-            child.expect(prompt)  # Wait for the prompt
-        if index == 1:
-            child.sendline("no")
-            child.expect(prompt)  # Wait for the prompt
+            if index == 0:
+                child.sendline("2048")  # Send enter to get default 2048
+                child.expect(prompt)  # Wait for the prompt
+            if index == 1:
+                child.sendline("no")
+                child.expect(prompt)  # Wait for the prompt
 
         # Final check to make sure MGMT stayed up
         xr_cli_wait_for_output('show ipv4 interface MgmtEth0/RP0/CPU0/0', '10.0.2.15')


### PR DESCRIPTION
Symptom
=======
Crypto (k9) image creation failed

Problem
=======
At "crypto key generate" step, an existing keypair triggered an additional prompt that wasn't expected.

Solution
========
Check the output of the "crypto key generate" command and accommodate the extra prompt by reusing the existing keypair

Testing
=======
Verified on both crypto and non-crypto images for 7.0.2.32I (iosxrv-full[k9]-x64-7.0.2.32I.iso)
